### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -97,6 +97,8 @@ jobs:
     name: Display Bad Apple
     runs-on: ubuntu-latest
     needs: mod-build # Runs after the mod-build job
+    permissions:
+      contents: read
 
     steps:
     - name: Download Bad Apple Animation


### PR DESCRIPTION
Potential fix for [https://github.com/Drowse-Lab/The-four-primitives-and-Weapons/security/code-scanning/4](https://github.com/Drowse-Lab/The-four-primitives-and-Weapons/security/code-scanning/4)

To fix the issue, we will add a `permissions` block to the `bad-apple-display` job. Since this job only downloads and processes a file, it does not require any write permissions. We will set the `contents` permission to `read`, which is sufficient for its tasks. This change will ensure that the job has the minimal permissions required and does not inherit unnecessary permissions from the repository.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
