### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/azure-functions-app-java.yml
+++ b/.github/workflows/azure-functions-app-java.yml
@@ -18,6 +18,9 @@
 
 name: Deploy Java project to Azure Function App
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: ["1.19.2"]


### PR DESCRIPTION
Potential fix for [https://github.com/Drowse-Lab/The-four-primitives-and-Weapons/security/code-scanning/5](https://github.com/Drowse-Lab/The-four-primitives-and-Weapons/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow. Based on the workflow's operations, it primarily needs `contents: read` to access the repository's contents. Additional permissions can be added if specific steps require them, but none are evident in the provided workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
