### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tweet-on-push.yml
+++ b/.github/workflows/tweet-on-push.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   tweet:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Potential fix for [https://github.com/Drowse-Lab/The-four-primitives-and-Weapons/security/code-scanning/10](https://github.com/Drowse-Lab/The-four-primitives-and-Weapons/security/code-scanning/10)

In general, to fix this issue you should add an explicit `permissions:` block either at the workflow root (applies to all jobs) or within the specific job. Since we only see a single `tweet` job and the warning is about that job’s `runs-on` line, the cleanest solution is to add a job-level `permissions:` section setting the token to read-only for repository contents, which is the minimal safe baseline when the token isn’t used.

Concretely, in `.github/workflows/tweet-on-push.yml`, under `jobs: tweet:` and at the same indentation level as `runs-on: ubuntu-latest`, insert:

```yaml
permissions:
  contents: read
```

This keeps existing functionality unchanged: the job continues to run on `ubuntu-latest`, uses the same secrets, and executes the same Node.js script, but the implicitly provided `GITHUB_TOKEN` is now restricted to read-only contents access. No new methods, imports, or additional definitions are required, as this is a pure YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
